### PR TITLE
Fix tree path for `ES Modules + server.ts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Use the following commands to quickly start a Remix v2 app with a basic Express 
 - [CommonJS + server.js](https://github.com/xHomu/remix-v2-server/tree/cjs-server.js): `npx create-remix --template https://github.com/xHomu/remix-v2-server/tree/cjs-server.js`
 - [CommonJS + server.ts](https://github.com/xHomu/remix-v2-server/tree/cjs-server.ts): `npx create-remix --template https://github.com/xHomu/remix-v2-server/tree/cjs-server.ts`
 - [ES Modules + server.js](https://github.com/xHomu/remix-v2-server/tree/esm-server.js): `npx create-remix --template https://github.com/xHomu/remix-v2-server/tree/esm-server.js`
-- [ES Modules + server.ts](https://github.com/xHomu/remix-v2-server/tree/cjs-server.ts): `npx create-remix --template https://github.com/xHomu/remix-v2-server/tree/cjs-server.ts`
+- [ES Modules + server.ts](https://github.com/xHomu/remix-v2-server/tree/cjs-server.ts): `npx create-remix --template https://github.com/xHomu/remix-v2-server/tree/esm-server.ts`
 
 ---
 


### PR DESCRIPTION
ES Modules + server.ts was pointing to an incorrect tree path (cjs-server.ts). Fixed it to point to correct tree (esm-server.ts)